### PR TITLE
Allow to pass null to setRefresh() to deactivate automatic cache cleanup again

### DIFF
--- a/src/TileProxy.php
+++ b/src/TileProxy.php
@@ -59,7 +59,13 @@ class TileProxy
         $this->option_ttl = (int)($hours * 3600);
     }
 
-    public function setRefresh(float $days): void
+    /**
+     * Set the number of days after which this tile proxy should automatically clean up old cached tiles.
+     * Setting it to null will disable the automatic cleanup.
+     * @param float|null $days
+     * @return void
+     */
+    public function setRefresh(?float $days): void
     {
         $this->option_refresh = $days;
     }

--- a/src/TileProxy.php
+++ b/src/TileProxy.php
@@ -59,6 +59,11 @@ class TileProxy
         $this->option_ttl = (int)($hours * 3600);
     }
 
+    public function setUserAgent(string $userAgent): void
+    {
+        $this->user_agent = $userAgent;
+    }
+
     /**
      * Set the number of days after which this tile proxy should automatically clean up old cached tiles.
      * Setting it to null will disable the automatic cleanup.

--- a/src/TileProxy.php
+++ b/src/TileProxy.php
@@ -132,7 +132,7 @@ class TileProxy
         $this->log("Saving to ".$save_to, self::LOGLEVEL_DEBUG);
         $this->log("mkdir ".$target_dir, self::LOGLEVEL_DEBUG);
         if(!is_dir($target_dir)) {
-            mkdir($target_dir, 0777, true);
+            @mkdir($target_dir, 0777, true);
         }
         // tile download
         $ch = curl_init($url);
@@ -178,8 +178,8 @@ class TileProxy
             }
 
         } else {
-            $content = file_get_contents($save_to);
-            unlink($save_to);
+            $content = @file_get_contents($save_to);
+            @unlink($save_to);
             throw new RuntimeException($content);
         }
     }

--- a/src/TileProxy.php
+++ b/src/TileProxy.php
@@ -146,7 +146,9 @@ class TileProxy
         fclose($fp);
 
         // check if image downloaded successfully
-        if($this->is_valid_image($save_to, $current_style)) {
+        if (curl_errno($ch) !== 0) {
+            throw new RuntimeException(curl_error($ch));
+        } elseif ($this->is_valid_image($save_to, $current_style)) {
 
             if($current_style->getImageChecktype() !== MapStyle::IMAGE_FORMAT_PNG) {
                 $this->log("to ". $current_style->getImageFormat(), self::LOGLEVEL_DEBUG);
@@ -156,19 +158,19 @@ class TileProxy
             }
 
             // TODO: dont save image in between
-            if($current_style->getModulate() || $current_style->getSepia() || $current_style->getNegate()) {
+            if ($current_style->getModulate() || $current_style->getSepia() || $current_style->getNegate()) {
                 $image_obj = new Imagick(realpath($save_to));
-                if($current_style->getModulate()) {
+                if ($current_style->getModulate()) {
                     $this->log("Modulating Image", self::LOGLEVEL_DEBUG);
                     $this->modulateImage($image_obj, $current_style->getModulateBrightness(), $current_style->getModulateSaturation(), $current_style->getModulateHue());
                 }
 
-                if($current_style->getSepia()) {
+                if ($current_style->getSepia()) {
                     $this->log("Sepia Image", self::LOGLEVEL_DEBUG);
                     $this->sepiaToneImage($image_obj, $current_style->getSepiaValue());
                 }
 
-                if($current_style->getNegate()) {
+                if ($current_style->getNegate()) {
                     $this->log("Negate Image", self::LOGLEVEL_DEBUG);
                     $this->negateImage($image_obj, $current_style->getNegateGrayOnly(), $current_style->getNegateChannel());
                 }
@@ -176,7 +178,9 @@ class TileProxy
             }
 
         } else {
+            $content = file_get_contents($save_to);
             unlink($save_to);
+            throw new RuntimeException($content);
         }
     }
 


### PR DESCRIPTION
A small thing I missed in my last commits. Nothing too important.